### PR TITLE
Ignore c_compiler and cxx_compiler variants on Windows - redux

### DIFF
--- a/.ci_support/win_.yaml
+++ b/.ci_support/win_.yaml
@@ -1,6 +1,3 @@
-c_compiler:
-- vs2008
-- vs2015
 conda_goarch:
 - amd64
 conda_gofile:
@@ -15,14 +12,9 @@ conda_goplatform:
 - linux-64
 - osx-64
 - win-64
-cxx_compiler:
-- vs2008
-- vs2015
 fortran_compiler:
 - flang
 zip_keys:
-- - c_compiler
-  - cxx_compiler
 - - conda_goplatform
   - conda_goos
   - conda_gofile

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: go-bootstrap
 
 build:
-  number: 1
+  number: 3
   binary_relocation: False
   detect_binary_files_with_prefix: False
   force_ignore_keys:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,9 @@ build:
   number: 1
   binary_relocation: False
   detect_binary_files_with_prefix: False
+  force_ignore_keys:  # [win]
+    - c_compiler      # [win]
+    - cxx_compiler    # [win]
 
 requirements:
   run:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->