### PR TITLE
Set GOPATH to $SRC_DIR during conda-build

### DIFF
--- a/recipe/activate-go-core.bat
+++ b/recipe/activate-go-core.bat
@@ -1,2 +1,6 @@
 @set "CONDA_GOROOT_BACKUP=%GOROOT%"
 @set "GOROOT=%CONDA_PREFIX%\go"
+
+if "%CONDA_BUILD%"==1 (
+  set GOPATH=%SRC_DIR%
+)

--- a/recipe/activate-go-platform.sh
+++ b/recipe/activate-go-platform.sh
@@ -3,3 +3,7 @@ export GOOS=@GOOS@
 
 export CONDA_GOARCH_BACKUP="${GOARCH:-}"
 export GOARCH=@GOARCH@
+
+if [[ $CONDA_BUILD == 1 ]]; then
+  export GOPATH=$SRC_DIR
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     folder: go-bootstrap
 
 build:
-  number: 0
+  number: 1
   binary_relocation: False
   detect_binary_files_with_prefix: False
   force_ignore_keys:  # [win]


### PR DESCRIPTION
<!--
Thanks for reporting your issue.
Please fill out the sections below.
-->
Issue:
As discussed in https://github.com/conda-forge/gosu-feedstock/pull/3#discussion_r202561014, I would like to suggest setting GOPATH to match the SRCDIR by default during conda-build. 

As I've built a few conda-packages for `go` source code I am always having to set GOPATH in my build.sh. It seems to be a common pattern that we could easily implement in the activate/deactivate scripts of the `go-compiler` packages. 

@nehaljwani, what are your thoughts?