### PR TITLE
Remove compiler definition from runtime

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     #  - 0001-addr2line.diff  # [linux]
 
 build:
-  number: 1000
+  number: 1001
   binary_relocation: False
   detect_binary_files_with_prefix: False
   force_ignore_keys:    # [win]
@@ -43,21 +43,16 @@ outputs:
       build:
         - {{ compiler('go14') }}
         - {{ compiler('c') }}              # [unix and cgo]
+        - {{ compiler('cxx') }}            # [unix and cgo]
         - {{ compiler('fortran') }}        # [unix and cgo]
         - {{ compiler('m2w64_c') }}        # [win and cgo]
+        - {{ compiler('m2w64_cxx') }}      # [win and cgo]
         - {{ compiler('m2w64_fortran') }}  # [win and cgo]
 
         - perl     # [not win]
         - m2-sed   # [win]
         - m2-grep  # [win]
 
-        # Packages needed for fixing tests
-        # see golang/go#23888
-      run:                                 # [cgo]
-        - {{ compiler('c') }}              # [unix and cgo]
-        - {{ compiler('fortran') }}        # [unix and cgo]
-        - {{ compiler('m2w64_c') }}        # [win and cgo]
-        - {{ compiler('m2w64_fortran') }}  # [win and cgo]
     test:
       files:
         - hello.go

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,10 @@ outputs:
         - perl     # [not win]
         - m2-sed   # [win]
         - m2-grep  # [win]
-
     test:
+      requires:
+        - {{ compiler('c') }}              # [unix and cgo]
+        - {{ compiler('m2w64_c') }}        # [win and cgo]
       files:
         - hello.go
         - hello-c.go  # [cgo]
@@ -86,6 +88,8 @@ outputs:
         - hello.go
         - hello-c.go
       requires:
+        - {{ compiler('c') }}              # [unix and cgo]
+        - {{ compiler('m2w64_c') }}        # [win and cgo]
         - posix    # [win]
         - m2-file  # [win]
         - m2-grep  # [win]


### PR DESCRIPTION
They are not mutually exclusive and it is causing problems with 
recipes that use cgo, e.g. singularity.


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->