### PR TITLE
Remove the fixedbugs/issue27836 unit test (go 1.12.x)

### DIFF
--- a/recipe/build-base.sh
+++ b/recipe/build-base.sh
@@ -43,6 +43,12 @@ rm -fr ${GOROOT}/pkg/obj
 cp -a ${GOROOT} ${PREFIX}/go
 
 
+# Remove Invalid UTF-8 Filename and conflict with libarchive
+# c.f. https://github.com/conda-forge/staged-recipes/pull/9535#discussion_r403512142
+# c.f. https://github.com/conda-forge/go-feedstock/issues/83
+rm -f "${PREFIX}"/go/test/fixedbugs/issue27836.go
+rm -rf "${PREFIX}"/go/test/fixedbugs/issue27836.dir
+
 # Right now, it's just go and gofmt, but might be more in the future!
 # We don't move files, and instead rely on soft-links
 mkdir -p ${PREFIX}/bin && pushd $_

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,7 +106,7 @@ outputs:
       license: BSD-3-Clause
       license_family: BSD
       license_file: go/LICENSE
-      summary: 'The Go ({{go_variant_str}}) compiler activation scripts for conda-build.'
+      summary: 'The Go ({{ go_variant_str }}) compiler activation scripts for conda-build.'
       description: |
           This package enables the CONDA_GO_COMPILER environment variable. 
           This variable is used by conda-forge's patched GoLang compiler to 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ build:
     - $RPATH/libc.so.6             # [linux and not cgo]
     - /usr/lib/libSystem.B.dylib   # [osx]
     - $SYSROOT\System32\winmm.dll  # [win]
-  number: 1
+  number: 2
 
 requirements:
   run:


### PR DESCRIPTION
This unit test was already removed in the windows builds.
We are now removing it from the Linux builds as well.

Close #83