### PR TITLE
skip tar archive tests, do not bundle testdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ Package license: BSD-3-Clause
 
 Summary: The Go Programming Language
 
-About go-nocgo
---------------
+About go-cgo
+------------
 
 Home: https://go.dev/
 
 Package license: BSD-3-Clause
 
-Summary: The Go Programming Language (nocgo)
+Summary: The Go Programming Language (cgo)
 
 Development: https://github.com/golang/
 
@@ -57,14 +57,14 @@ It's a fast, statically typed, compiled language that feels like a
 dynamically typed, interpreted language.
 
 
-About go-cgo
-------------
+About go-nocgo
+--------------
 
 Home: https://go.dev/
 
 Package license: BSD-3-Clause
 
-Summary: The Go Programming Language (cgo)
+Summary: The Go Programming Language (nocgo)
 
 Development: https://github.com/golang/
 

--- a/recipe/build-base.sh
+++ b/recipe/build-base.sh
@@ -62,6 +62,8 @@ popd
 # Don't need the cached build objects
 rm -fr ${GOROOT}/pkg/obj
 
+# Don't need the test files from the source
+find ${GOROOT}/src -type d -name "testdata" -exec rm -rf \;
 
 # Dropping the verbose option here, +8000 files
 cp -a ${GOROOT} ${PREFIX}/go

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ build:
     - $RPATH/libc.so.6             # [linux and not cgo]
     - /usr/lib/libSystem.B.dylib   # [osx]
     - $SYSROOT\System32\winmm.dll  # [win]
-  number: 0
+  number: 1
   skip: true  # [linux and s390x]
 
 requirements:

--- a/recipe/nocgo/test.sh
+++ b/recipe/nocgo/test.sh
@@ -43,7 +43,7 @@ case $(uname -s) in
         ;;
       *)
         # Expect PASS
-        go tool dist test -v -no-rebuild
+        go tool dist test -v -no-rebuild -run='!^archive/tar'
         ;;
     esac
     ;;


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

There's a troublesome file in the test data included in the packages. It's the header-only tar test file. This breaks seemingly all existing go package builds for me. This PR removes the testdata folders from the package, and also skips the tar archive tests to avoid this same file.

It could be a problem with just my machine, but I haven't been able to find any mention of the issue, and this seems like a benign change to avoid the issue.
