### PR TITLE
Lower gcc requirements

### DIFF
--- a/.ci_support/linux_64_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
+++ b/.ci_support/linux_64_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - nocgo
 go_variant_ver:

--- a/.ci_support/linux_64_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
+++ b/.ci_support/linux_64_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - cgo
 go_variant_ver:

--- a/.ci_support/linux_aarch64_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
+++ b/.ci_support/linux_aarch64_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - nocgo
 go_variant_ver:

--- a/.ci_support/linux_aarch64_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
+++ b/.ci_support/linux_aarch64_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - cgo
 go_variant_ver:

--- a/.ci_support/linux_ppc64le_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
+++ b/.ci_support/linux_ppc64le_cgofalsego_variant_strnocgogo_variant_ver2.2.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - nocgo
 go_variant_ver:

--- a/.ci_support/linux_ppc64le_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
+++ b/.ci_support/linux_ppc64le_cgotruego_variant_strcgogo_variant_ver2.3.0.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '13'
+- '11'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -17,13 +17,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '13'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '13'
+- '11'
 go_variant_str:
 - cgo
 go_variant_ver:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -36,5 +36,11 @@ zip_keys:
     - go_variant_ver
     - cgo
 
-c_stdlib_version:   # [linux]
-  - "2.17"          # [linux]
+c_stdlib_version:     # [linux]
+  - "2.17"            # [linux]
+c_compiler_version:   # [linux]
+  - "11"              # [linux]
+cxx_compiler_version: # [linux]
+  - "11"              # [linux]
+fortran_compiler_version: # [linux]
+  - "11"                  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ build:
     - $RPATH/libc.so.6             # [linux and not cgo]
     - /usr/lib/libSystem.B.dylib   # [osx]
     - $SYSROOT\System32\winmm.dll  # [win]
-  number: 0
+  number: 1
   skip: true  # [linux and s390x]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I'm trying to solve a build issue for https://github.com/conda-forge/ollama-feedstock/pull/25 where I need CUDA 11 and thus gxx 11 and Go 1.23. I don't fully understand what I'm doing here but I think we might be able to lower the compiler requirements for this package

It looks like according to https://go.dev/wiki/MinimumRequirements#cgo we just need gcc >= 4.6