### PR TITLE
Actually delete src testdata, which the existing find never did

### DIFF
--- a/recipe/build-base.sh
+++ b/recipe/build-base.sh
@@ -63,7 +63,7 @@ popd
 rm -fr ${GOROOT}/pkg/obj
 
 # Don't need the test files from the source
-find ${GOROOT}/src -type d -name "testdata" -exec rm -rf \;
+find ${GOROOT}/src -type d -name "testdata" -prune -exec rm -rf {} +
 
 # Dropping the verbose option here, +8000 files
 cp -a ${GOROOT} ${PREFIX}/go
@@ -99,5 +99,6 @@ mkdir -p "${PREFIX}/etc/conda/env_vars.d"
 cp "${RECIPE_DIR}/env.json" "${PREFIX}/etc/conda/env_vars.d/${PKG_NAME}.json"
 
 # These tests fail as we bake in the compiler path
+mkdir -p "${PREFIX}/go/src/cmd/go/testdata/script"
 echo skip > "${PREFIX}/go/src/cmd/go/testdata/script/autocgo.txt"
 echo skip > "${PREFIX}/go/src/cmd/go/testdata/script/build_darwin_cc_arch.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ source:
     sha256: 2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204  # [build_platform == "osx-arm64"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [linux and s390x]
 
 outputs:


### PR DESCRIPTION
> 🤖 This PR was opened by **Claude Code**, running as an automated assistant on behalf of @hmaarrfk. Please direct any questions to him.

**This is an experiment, opened to get a CI answer. Please do not merge on green without reading the caveat at the bottom.**

## The bug

```sh
find ${GOROOT}/src -type d -name "testdata" -exec rm -rf \;
```

is missing `{}`. Every match runs `rm -rf` with no operand, which under `-f` is a silent success. So the line has never deleted anything, and every `testdata` directory in the go source tree has been shipped for as long as it has been there.

Fixed with `{}` and `-prune`, so a matched directory is deleted once instead of being descended into:

```sh
find ${GOROOT}/src -type d -name "testdata" -prune -exec rm -rf {} +
```

Measured on the go 1.26.6 tree: **15,013 files → 10,953**. In an installed environment that is 4,494 of 16,762 entries — roughly 27%.

`cmd/go/testdata/script/` is one of the directories removed, so the two `echo skip >` lines further down would fail under `set -euxo pipefail`. Added a `mkdir -p` to recreate just that one directory so the `autocgo` and `build_darwin_cc_arch` skips still work.

Build number bumped to 1, since 1.26.6 build 0 is published.

## Why now

Downstream, conda-forge/go-compiler-feedstock#4 fails intermittently on `osx_64_go_variant_strcgo` when rattler-build removes the test directory:

```
Error:   × Test failed
  ╰─▶ Directory not empty (os error 66)
```

The `go` package is 16,701 of that test environment's 16,762 entries, so it dominates how long the delete takes. Shrinking it is the only lever available on our side.

## The caveat — please read before merging

**I do not expect this to fix the downstream failure, and I expect this PR's own CI to go red.**

- `go tool dist test` reads `testdata` extensively across the standard library. Removing it will likely fail this feedstock's own test suite. If that happens, this PR should be closed, not patched around.
- The `nocgo` variant installs the same `GOROOT` and deletes nearly the same number of files, and it has passed every run. So there is no evidence that 27% fewer files crosses any threshold. The observed 2-of-3 vs 0-of-3 split between variants is n=3 noise, not a size correlation.
- Upstream go ships `testdata` in its official distributions. Removing it is a behaviour change for anyone running `go test std`.

The actual cause of the downstream failure looks like a missing retry in rattler-build: `remove_dir_all_force` retries only on `PermissionDenied`, and its `try_remove_with_retry` helper — written specifically to survive "antivirus, indexers, etc." — is `#[cfg(windows)]`. On macOS an `ENOTEMPTY` from an indexer touching the tree mid-delete is fatal.

So this PR is worth having on its own merits if the tests survive — the line is plainly broken and the package is carrying 27% dead weight — but it should not be treated as the fix for #4.
