### PR TITLE
get rid of _go_select mutex package

### DIFF
--- a/.ci_support/linux_64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/linux_64_cgofalsego_variant_strnocgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 target_platform:
 - linux-64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/linux_64_cgotruego_variant_strcgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 target_platform:
 - linux-64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_aarch64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/linux_aarch64_cgofalsego_variant_strnocgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 target_platform:
 - linux-aarch64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_aarch64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/linux_aarch64_cgotruego_variant_strcgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 target_platform:
 - linux-aarch64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_ppc64le_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/linux_ppc64le_cgofalsego_variant_strnocgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 target_platform:
 - linux-ppc64le
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_ppc64le_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/linux_ppc64le_cgotruego_variant_strcgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 target_platform:
 - linux-ppc64le
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_riscv64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/linux_riscv64_cgofalsego_variant_strnocgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 target_platform:
 - linux-riscv64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/linux_riscv64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/linux_riscv64_cgotruego_variant_strcgo.yaml
@@ -24,8 +24,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 target_platform:
 - linux-riscv64
 zip_keys:
@@ -33,5 +31,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/osx_64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/osx_64_cgofalsego_variant_strnocgo.yaml
@@ -26,8 +26,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
@@ -37,5 +35,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/osx_64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/osx_64_cgotruego_variant_strcgo.yaml
@@ -26,8 +26,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:
@@ -37,5 +35,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/osx_arm64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/osx_arm64_cgofalsego_variant_strnocgo.yaml
@@ -26,8 +26,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
@@ -37,5 +35,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/osx_arm64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/osx_arm64_cgotruego_variant_strcgo.yaml
@@ -26,8 +26,6 @@ fortran_compiler_version:
 - '15'
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:
@@ -37,5 +35,4 @@ zip_keys:
   - cxx_compiler_version
   - fortran_compiler_version
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/win_64_cgofalsego_variant_strnocgo.yaml
+++ b/.ci_support/win_64_cgofalsego_variant_strnocgo.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 go_variant_str:
 - nocgo
-go_variant_ver:
-- 2.2.0
 m2w64_c_compiler:
 - gcc
 m2w64_c_compiler_version:
@@ -28,5 +26,4 @@ target_platform:
 - win-64
 zip_keys:
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.ci_support/win_64_cgotruego_variant_strcgo.yaml
+++ b/.ci_support/win_64_cgotruego_variant_strcgo.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 go_variant_str:
 - cgo
-go_variant_ver:
-- 2.3.0
 m2w64_c_compiler:
 - gcc
 m2w64_c_compiler_version:
@@ -28,5 +26,4 @@ target_platform:
 - win-64
 zip_keys:
 - - go_variant_str
-  - go_variant_ver
   - cgo

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,7 +28,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -40,7 +40,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -52,7 +52,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -64,7 +64,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -76,7 +76,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -88,7 +88,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -100,7 +100,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -112,7 +112,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -124,7 +124,7 @@ jobs:
             build_platform: win-64
             build_workspace_dir: D:\\bld\\
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: windows
             pagefile_size: 0
             resize_partitions: False
@@ -136,7 +136,7 @@ jobs:
             build_platform: win-64
             build_workspace_dir: D:\\bld\\
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: windows
             pagefile_size: 0
             resize_partitions: False
@@ -146,6 +146,14 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Manage disk space
+      env:
+        FREE_DISK_SPACE: ${{ matrix.free_disk_space }}
+        OS: ${{ matrix.os }}
+      shell: bash
+      run: |
+        .scripts/free_disk_space.sh "${FREE_DISK_SPACE}"
     - name: Configure binfmt_misc
       if: matrix.os == 'ubuntu'
       shell: bash

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Package license: BSD-3-Clause
 
 Summary: The Go Programming Language
 
-Development: https://github.com/golang/
+Development: https://github.com/golang/go
 
 Documentation: https://go.dev/doc
 
@@ -34,7 +34,7 @@ Package license: BSD-3-Clause
 
 Summary: The Go Programming Language (cgo)
 
-Development: https://github.com/golang/
+Development: https://github.com/golang/go
 
 Documentation: https://go.dev/doc
 
@@ -55,7 +55,7 @@ Package license: BSD-3-Clause
 
 Summary: The Go Programming Language (nocgo)
 
-Development: https://github.com/golang/
+Development: https://github.com/golang/go
 
 Documentation: https://go.dev/doc
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,6 @@
+workflow_settings:
+  free_disk_space: quick
 azure:
-  free_disk_space: true
   settings_linux:
     swapfile_size: 8GiB
 bot:

--- a/recipe/README.md
+++ b/recipe/README.md
@@ -2,7 +2,6 @@
 
 The go-feedstock builds 2 versions of the go compiler, cgo and nocgo.
 The end-user is only allowed to install one in any given conda environment.
-This constraint is enforced by conda using the `_go_select` **mutex** package.
 
 The cgo version is built with `CGO_ENABLED=1` and it ties to the conda-forge compilers. 
 This is the version that most closely matches the upstream release, with the difference that we use our compilers.

--- a/recipe/build-base.bat
+++ b/recipe/build-base.bat
@@ -52,5 +52,11 @@ if errorlevel 1 exit 1
 :: JSON files under '%PREFIX%\etc\conda\env_vars.d\' containing environment variables as key-value pairs
 :: are sourced automatically upon activation.
 :: Ref.: https://github.com/conda/conda/issues/6820#issuecomment-1269581626
+::
+:: The build prefix is written out literally; conda rewrites it to the
+:: installation prefix when the package is unpacked (text prefix replacement).
+:: Forward slashes are used so that the paths need no JSON escaping.
 if not exist "%PREFIX%\etc\conda\env_vars.d" mkdir "%PREFIX%\etc\conda\env_vars.d"
-copy "%RECIPE_DIR%\env.json" "%PREFIX%\etc\conda\env_vars.d\%PKG_NAME%.json"
+set "FWD_PREFIX=%PREFIX:\=/%"
+echo {"GOROOT": "%FWD_PREFIX%/go", "GOTOOLCHAIN": "local"} > "%PREFIX%\etc\conda\env_vars.d\%PKG_NAME%.json"
+if errorlevel 1 exit 1

--- a/recipe/build-base.sh
+++ b/recipe/build-base.sh
@@ -106,8 +106,16 @@ find ../go/bin -type f -exec ln -s {} . \;
 # JSON files under '$PREFIX/etc/conda/env_vars.d/' containing environment variables as key-value pairs
 # are sourced automatically upon activation.
 # Ref.: https://github.com/conda/conda/issues/6820#issuecomment-1269581626
+#
+# The build prefix is written out literally; conda rewrites it to the
+# installation prefix when the package is unpacked (text prefix replacement).
 mkdir -p "${PREFIX}/etc/conda/env_vars.d"
-cp "${RECIPE_DIR}/env.json" "${PREFIX}/etc/conda/env_vars.d/${PKG_NAME}.json"
+cat > "${PREFIX}/etc/conda/env_vars.d/${PKG_NAME}.json" <<EOF
+{
+  "GOROOT": "${PREFIX}/go",
+  "GOTOOLCHAIN": "local"
+}
+EOF
 
 # These tests fail as we bake in the compiler path
 echo skip > "${PREFIX}/go/src/cmd/go/testdata/script/autocgo.txt"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,15 +14,9 @@
 c_stdlib_version:         # [osx]
   - '13.0'                # [osx]
 
-# Select the GO variants that we are building
-# The variant names, and versions come from
-# https://github.com/conda-forge/_go_select-feedstock/blob/main/recipe/conda_build_config.yaml
 go_variant_str:
   - cgo
   - nocgo
-go_variant_ver:
-  - 2.3.0
-  - 2.2.0
 
 # One-hot-encoding of the variant selection above
 cgo:
@@ -34,5 +28,4 @@ cgo:
 zip_keys:
   -
     - go_variant_str
-    - go_variant_ver
     - cgo

--- a/recipe/env.json
+++ b/recipe/env.json
@@ -1,3 +1,0 @@
-{
-  "GOTOOLCHAIN": "local"
-}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "1.27.1"
+  build: 3
 
 recipe:
   name: go-${{ go_variant_str }}-split
@@ -51,12 +52,13 @@ source:
       target_directory: go-bootstrap
 
 build:
-  number: 3
+  number: ${{ build }}
 
 outputs:
   - package:
       name: go
     build:
+      string: ${{ hash }}_${{ go_variant_str }}_${{ build }}
       script:
         file: ${{ go_variant_str }}/build
       dynamic_linking:
@@ -77,9 +79,9 @@ outputs:
             - ${{ stdlib("m2w64_c") }}
             - ${{ compiler('m2w64_cxx') }}
             - ${{ compiler('m2w64_fortran') }}
-      run:
-        - _go_select ==${{ go_variant_ver }} ${{ go_variant_str }}
       run_constraints:
+        # TODO: remove on next go version (>1.27.1), this is just to not accidentally select the wrong activation script
+        - _go_select <0.0a0
         # https://github.com/prefix-dev/rattler-build/issues/2792
         - if: unix and cgo
           then:
@@ -165,7 +167,7 @@ outputs:
           - go help
 
 about:
-  homepage: https://go.dev/
+  homepage: https://go.dev
   license: BSD-3-Clause
   license_file: go/LICENSE
   summary: The Go Programming Language (${{ go_variant_str }})
@@ -178,7 +180,7 @@ about:
     It's a fast, statically typed, compiled language that feels like a
     dynamically typed, interpreted language.
   documentation: https://go.dev/doc
-  repository: https://github.com/golang/
+  repository: https://github.com/golang/go
 
 extra:
   feedstock-name: go

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -58,7 +58,7 @@ outputs:
   - package:
       name: go
     build:
-      string: ${{ hash }}_${{ go_variant_str }}_${{ build }}
+      string: ${{ go_variant_str }}_h${{ hash }}_${{ build }}
       script:
         file: ${{ go_variant_str }}/build
       dynamic_linking:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -137,24 +137,12 @@ outputs:
       license_file: go/LICENSE
       summary: The Go Programming Language
 
+  # meta-package for non-feedstock use
   - package:
       name: go-${{ go_variant_str }}
-    build:
-      dynamic_linking:
-        binary_relocation: false
-        # test data links to these DSOs
-        missing_dso_allowlist:
-          - if: linux and not cgo
-            then: $RPATH/libc.so.6
-          - if: osx
-            then: /usr/lib/libSystem.B.dylib
-          - if: win
-            then: $SYSROOT\System32\winmm.dll
-      prefix_detection:
-        ignore_binary_files: true
     requirements:
       run:
-        - ${{ pin_subpackage('go', exact=True) }}
+        - ${{ pin_subpackage('go', exact=true) }}
         - if: unix and cgo
           then: ${{ compiler('c') }}
         - if: win and cgo

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   version: "1.27.1"
-  build: 3
+  build: 4
 
 recipe:
   name: go-${{ go_variant_str }}-split

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -114,11 +114,21 @@ outputs:
           - if: unix
             then:
               - ./${{ go_variant_str }}/test.sh
+              # etc/conda/env_vars.d/go.json is activated and its baked-in build
+              # prefix was rewritten to the installation prefix
               - test "$GOTOOLCHAIN" = "local"
+              - test "$GOROOT" = "$CONDA_PREFIX/go"
+              - test "$(go env GOROOT)" = "$CONDA_PREFIX/go"
           - if: win
             then:
               - ${{ go_variant_str }}\test.bat
+              # etc/conda/env_vars.d/go.json is activated and its baked-in build
+              # prefix was rewritten to the installation prefix. The JSON stores
+              # forward slashes, so compare slash-insensitively.
               - if not "%GOTOOLCHAIN%"=="local" exit /b 1
+              - 'if not "%GOROOT:\=/%"=="%CONDA_PREFIX:\=/%/go" exit /b 1'
+              - 'for /f "delims=" %%i in (''go env GOROOT'') do set "GO_GOROOT=%%i"'
+              - 'if not "%GO_GOROOT:\=/%"=="%CONDA_PREFIX:\=/%/go" exit /b 1'
     about:
       homepage: https://go.dev/
       license: BSD-3-Clause


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #343, closes #274

since go doesn't have any run exports that are relevant for cgo vs nocgo, there is not really a need for any mutex packages. just having the variant encoded in the build string is enough as two versions of the same conda package can anyway never be installed at the same time

follow-up: https://github.com/conda-forge/go-activation-feedstock/pull/120